### PR TITLE
Allow riddle to compile when targetting wasm32

### DIFF
--- a/riddle-audio/Cargo.toml
+++ b/riddle-audio/Cargo.toml
@@ -14,9 +14,13 @@ riddle-mp3 = ["rodio/mp3"]
 riddle-common = {path = "../riddle-common"}
 
 futures = "0.3"
-rodio = { version = "0.13", features=["wav", "vorbis"] }
+rodio = { version = "0.13", default-features=false, features=["wav", "vorbis"] }
 thiserror = "1.0"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies.rodio]
+version = "^0.13.1"
+default-features = false
+features = ["wav", "vorbis", "wasm-bindgen"]
 
 [dev-dependencies]
 riddle = {path = "../riddle"}

--- a/riddle-input/src/input_system.rs
+++ b/riddle-input/src/input_system.rs
@@ -381,7 +381,7 @@ impl ext::InputSystemExt for InputSystem {
 	}
 
 	fn take_input_events(&self) -> Vec<InputEvent> {
-		std::mem::replace(&mut self.outgoing_input_events.lock().unwrap(), vec![])
+		std::mem::take(&mut self.outgoing_input_events.lock().unwrap())
 	}
 }
 

--- a/riddle-platform-common/src/scancode.rs
+++ b/riddle-platform-common/src/scancode.rs
@@ -228,7 +228,7 @@ impl From<u32> for Scancode {
 	}
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_arch = "wasm32", target_os = "windows"))]
 impl From<u32> for Scancode {
 	fn from(sc: u32) -> Self {
 		match sc {

--- a/riddle-platform-winit/Cargo.toml
+++ b/riddle-platform-winit/Cargo.toml
@@ -15,5 +15,12 @@ thiserror = "1.0"
 
 winit = "0.24"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies.winit]
+version = "0.24"
+features = ["web-sys"]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "0.3"
+
 [dev-dependencies]
 riddle = {path = "../riddle"}

--- a/riddle-platform-winit/src/window.rs
+++ b/riddle-platform-winit/src/window.rs
@@ -80,6 +80,20 @@ impl Window {
 				.map_err(|_| PlatformError::WindowInitFailure)
 		})?;
 
+		#[cfg(target_arch = "wasm32")]
+		{
+			use winit::platform::web::WindowExtWebSys;
+
+			let canvas = winit_window.canvas();
+
+			let window = web_sys::window().unwrap();
+			let document = window.document().unwrap();
+			let body = document.body().unwrap();
+
+			body.append_child(&canvas)
+				.expect("Append canvas to HTML body");
+		}
+
 		args.configure_window(&winit_window);
 
 		let event_sub = EventSub::new_with_filter(Self::event_filter);

--- a/riddle-renderer-wgpu/Cargo.toml
+++ b/riddle-renderer-wgpu/Cargo.toml
@@ -16,9 +16,14 @@ riddle-platform-winit = {path = "../riddle-platform-winit"}
 bytemuck = "1.3"
 glam = {version= "0.11", features=["mint"]}
 futures = "0.3"
+log = "0.4"
 thiserror = "1.0"
 wgpu = "0.7"
 mint = "0.5"
 
 [dev-dependencies]
 riddle = {path = "../riddle"}
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.wgpu]
+version = "0.7"
+features = ["webgl"]

--- a/riddle-renderer-wgpu/src/wgpu_ext/window_device.rs
+++ b/riddle-renderer-wgpu/src/wgpu_ext/window_device.rs
@@ -21,6 +21,7 @@ impl WindowWGPUDevice {
 		let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
 		let surface = unsafe { instance.create_surface(window) };
 
+		log::debug!("Initializing WGPU adapter...");
 		let adapter =
 			futures::executor::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
 				power_preference: wgpu::PowerPreference::HighPerformance,
@@ -28,6 +29,7 @@ impl WindowWGPUDevice {
 			}))
 			.ok_or(RendererError::APIInitError("Failed to get WGPU adapter"))?;
 
+		log::debug!("Initializing WGPU device...");
 		let (device, queue) = futures::executor::block_on(adapter.request_device(
 			&wgpu::DeviceDescriptor {
 				..Default::default()

--- a/riddle-time/Cargo.toml
+++ b/riddle-time/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 riddle-common = {path = "../riddle-common"}
+instant = "0.1"
 
 [dev-dependencies]
 riddle = {path = "../riddle"}

--- a/riddle-time/src/time_system.rs
+++ b/riddle-time/src/time_system.rs
@@ -32,7 +32,7 @@ impl TimeSystem {
 	}
 
 	/// Get the reference time for this frame. Captured during [`ext::TimeSystemExt::process_frame`].
-	pub fn frame_instant(&self) -> std::time::Instant {
+	pub fn frame_instant(&self) -> instant::Instant {
 		self.frame_time.lock().unwrap().frame_instant
 	}
 
@@ -85,22 +85,22 @@ impl ext::TimeSystemExt for TimeSystem {
 }
 
 struct FrameTime {
-	frame_instant: std::time::Instant,
-	frame_delta: std::time::Duration,
+	frame_instant: instant::Instant,
+	frame_delta: instant::Duration,
 	fps: f32,
 }
 
 impl FrameTime {
 	fn new() -> Self {
 		Self {
-			frame_instant: std::time::Instant::now(),
+			frame_instant: instant::Instant::now(),
 			frame_delta: Default::default(),
 			fps: 0.0,
 		}
 	}
 
 	fn update(&mut self) {
-		let now = std::time::Instant::now();
+		let now = instant::Instant::now();
 		self.frame_delta = now.duration_since(self.frame_instant);
 		self.fps = 1.0 / self.frame_delta.as_secs_f32().max(0.0001);
 		self.frame_instant = now;

--- a/riddle/Cargo.toml
+++ b/riddle/Cargo.toml
@@ -22,6 +22,7 @@ riddle-renderer-wgpu = {version = "0.3.0-dev", path = "../riddle-renderer-wgpu",
 riddle-time = {version = "0.3.0-dev", path = "../riddle-time"}
 riddle-platform-winit = {version = "0.3.0-dev", path = "../riddle-platform-winit"}
 
+log = "0.4"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/riddle/src/state.rs
+++ b/riddle/src/state.rs
@@ -22,13 +22,26 @@ pub struct RiddleState {
 
 impl RiddleState {
 	pub(crate) fn new() -> Result<(Self, MainThreadState)> {
+		log::debug!("Initializing platform...");
 		let (platform_system, platform_main_thread) = PlatformSystem::new_shared();
+		log::debug!("Platform initialized");
+
+		log::debug!("Initializing input...");
 		let (input_system, input_main_thread) =
 			InputSystem::new_shared(platform_system.event_pub())?;
+		log::debug!("Input initialized");
+
+		log::debug!("Initializing time...");
 		let time = TimeSystem::new_shared();
+		log::debug!("Time initialized");
 
 		#[cfg(feature = "riddle-audio")]
-		let (audio, audio_main_thread) = AudioSystem::new_shared()?;
+		let (audio, audio_main_thread) = {
+			log::debug!("Initializing audio...");
+			let result = AudioSystem::new_shared()?;
+			log::debug!("Audio initialized");
+			result
+		};
 
 		let riddle_state = RiddleState {
 			platform: platform_system,


### PR DESCRIPTION
Allow riddle to compile for wam32. This does **not** mean that riddle works on wasm32 at this point in any meaningful way.